### PR TITLE
add pre-commit hook for doctoc

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -27,3 +27,11 @@ npm install -g doctoc
 ```
 doctoc README.md
 ```
+
+### Pre-commit hook
+
+You can copy the pre-commit hook over so that it will generate the TOC on commit:
+
+```
+cp pre-commit.sh .git/hooks/pre-commit
+```

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+which doctoc >> /dev/stdout
+
+if [ $? -ne 0 ]; then
+    echo "Doctoc not installed - see HOWTO.md for installation instructions."
+    echo "Skipping Table of Contents generation"
+    exit 0;
+fi
+
+doctoc README.md
+git add README.md


### PR DESCRIPTION
Adds pre-commit hook (with install instructions) so people don't forget (like I did) to generate the TOC before pushing